### PR TITLE
Explicitly allow merging into/from empty nodes.

### DIFF
--- a/include/dr_param/yaml.hpp
+++ b/include/dr_param/yaml.hpp
@@ -107,7 +107,12 @@ std::string toString(YAML::NodeType::value);
 estd::result<YAML::Node, estd::error> readYamlFile(std::string const & path);
 
 /// Merge the nodes of map_b into map_a and overwrite if it already exists in map_a.
-YamlResult<void> mergeYamlNodes(YAML::Node map_a, YAML::Node map_b);
+YamlResult<void> mergeYamlNodes(YAML::Node & map_a, YAML::Node map_b);
+
+/// Merge the nodes of map_b into map_a and overwrite if it already exists in map_a.
+inline YamlResult<void> mergeYamlNodes(YAML::Node && map_a, YAML::Node map_b) {
+	return mergeYamlNodes(map_a, map_b);
+}
 
 /// Set a variable to a subkey of a node if it exists.
 /**

--- a/src/yaml.cpp
+++ b/src/yaml.cpp
@@ -105,12 +105,12 @@ estd::result<YAML::Node, estd::error> readYamlFile(std::string const & path) {
 	return YAML::Load(buffer.str());
 }
 
-YamlResult<void> mergeYamlNodes(YAML::Node map_a, YAML::Node map_b) {
+YamlResult<void> mergeYamlNodes(YAML::Node & map_a, YAML::Node map_b) {
 	// Check if the arguments are maps.
-	if (!map_a.IsMap()) {
+	if (!map_a.IsMap() && !map_a.IsNull()) {
 		return YamlError{"tried to merge into a YAML node that is not a map"};
 	}
-	if (!map_b.IsMap()) {
+	if (!map_b.IsMap() && !map_b.IsNull()) {
 		return YamlError{"tried to merge from a YAML node that is not a map"};
 	}
 

--- a/test/yaml.cpp
+++ b/test/yaml.cpp
@@ -3,6 +3,7 @@
 
 /// Fizyr
 #include "yaml.hpp"
+#include <estd/result/catch_string_conversions.hpp>
 
 namespace dr {
 
@@ -60,6 +61,36 @@ TEST_CASE("merge yaml nodes recursive", "[yaml_node]") {
 	REQUIRE(map_a["sub"]["list"].size() == 1);
 	REQUIRE(map_a["sub"]["list"][0].as<int>() == 5);
 	REQUIRE(map_a["sub"]["year"].as<int>() == 2019);
+}
+
+TEST_CASE("Merge into an empty YAML node", "[yaml_node]") {
+	YAML::Node a;
+
+	YAML::Node b;
+	b["aap"] = 1;
+	b["noot"] = 2;
+	b["mies"] = 3;
+
+	REQUIRE(mergeYamlNodes(a, b));
+
+	CHECK(a.size() == 3);
+	CHECK(a["aap"].as<int>() == 1);
+	CHECK(a["noot"].as<int>() == 2);
+	CHECK(a["mies"].as<int>() == 3);
+}
+
+TEST_CASE("Merge from an empty YAML node", "[yaml_node]") {
+	YAML::Node a;
+	a["aap"] = 1;
+	a["noot"] = 2;
+	a["mies"] = 3;
+
+	REQUIRE(mergeYamlNodes(a, YAML::Node{}));
+
+	CHECK(a.size() == 3);
+	CHECK(a["aap"].as<int>() == 1);
+	CHECK(a["noot"].as<int>() == 2);
+	CHECK(a["mies"].as<int>() == 3);
 }
 
 }


### PR DESCRIPTION
This PR makes it possible to merge from and into empy YAML nodes.

I didn't add a changelog entry since `mergeYamlNodes` hasn't been released yet.

Would allow some simplification as suggested by @hgaiser in the command server.