### PR TITLE
Mark function definitions as inline to avoid ODR violations and linking errors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## master
+### Changed
+- Mark function definitions from `DR_PARAM_DEFINE_YAML_*` as inline to allow them to be used in headers.
 
 ## 2.0.0 - 2021-01-05
 ### Changed

--- a/include/dr_param/yaml_macros.hpp
+++ b/include/dr_param/yaml_macros.hpp
@@ -46,7 +46,7 @@
  *     // convert value, return a YAML::Node
  *   }
  */
-#define DR_PARAM_DEFINE_YAML_ENCODE(TYPE, VALUE) ::YAML::Node estd::conversion<TYPE, YAML::Node>::perform(TYPE const & VALUE)
+#define DR_PARAM_DEFINE_YAML_ENCODE(TYPE, VALUE) inline ::YAML::Node estd::conversion<TYPE, YAML::Node>::perform(TYPE const & VALUE)
 
 /// Define a YAML decoding conversion.
 /**
@@ -60,7 +60,7 @@
  *     // Return a dr::YamlResult<MyStruct>
  *   }
  */
-#define DR_PARAM_DEFINE_YAML_DECODE(TYPE, NODE) ::dr::YamlResult<TYPE> estd::conversion<YAML::Node, ::dr::YamlResult<TYPE>>::perform(::YAML::Node const & NODE)
+#define DR_PARAM_DEFINE_YAML_DECODE(TYPE, NODE) inline ::dr::YamlResult<TYPE> estd::conversion<YAML::Node, ::dr::YamlResult<TYPE>>::perform(::YAML::Node const & NODE)
 
 /// Define a YAML decoding conversion.
 /**


### PR DESCRIPTION
Putting non-inline function definitions in headers is a recipe for disaster. It can lead to ODR violations and linking errors.

This PR simply makes all function definitions from the macros inline. It should have no impact on definitions in source files.