### PR TITLE
deal with deprecated boost::filesystem::path::normal

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,2 @@
+# Unreleased
+[change][major] Replace deprecated `boost::filesystem::path::normalize` with less powerfull `boost::filesystem::path::lexically_normal`.

--- a/src/yaml_preprocess.cpp
+++ b/src/yaml_preprocess.cpp
@@ -43,14 +43,15 @@ namespace {
 		boost::filesystem::path path = expandVariables(node.as<std::string>(), variables);
 		if (path.empty()) return estd::error{std::errc::invalid_argument, "tried to include empty path"};
 		if (path.is_relative()) path = path_info.dir / path;
-		path.normalize();
+		// TOOD: should we just use lexically_normal() instead?
+		auto normal_path = boost::filesystem::canonical(path);
 
 		// Parse node, process tags and overwrite original.
 		node.SetTag("");
-		node = readYamlFile(path.native()).value();
+		node = readYamlFile(normal_path.native()).value();
 
 		// Queue node for reprocessing.
-		work.push_back(Work{PathInfo{path.parent_path(), path}, {node}});
+		work.push_back(Work{PathInfo{normal_path.parent_path(), normal_path}, {node}});
 
 		return estd::in_place_valid;
 	}

--- a/src/yaml_preprocess.cpp
+++ b/src/yaml_preprocess.cpp
@@ -43,8 +43,7 @@ namespace {
 		boost::filesystem::path path = expandVariables(node.as<std::string>(), variables);
 		if (path.empty()) return estd::error{std::errc::invalid_argument, "tried to include empty path"};
 		if (path.is_relative()) path = path_info.dir / path;
-		// TOOD: should we just use lexically_normal() instead?
-		auto normal_path = boost::filesystem::canonical(path);
+		auto normal_path = path.lexically_normal();
 
 		// Parse node, process tags and overwrite original.
 		node.SetTag("");


### PR DESCRIPTION
Update: Lexically normal is the closest equivalent to what we had before, but it is explicitly less powerfull then the old normalize, which (afaik) did both lexical normalization and canonization (and maybe other stuff?).

We should be reaaaaaally careful with this one, because it will 100% change the behavior of file loading when using the `!include` macro in yaml files. We should confirm that this won't break anything in our balena systems.